### PR TITLE
correct documentation for get_private_key_string

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -180,7 +180,12 @@ and is the format that is produced by running C<openssl rsa -pubout>.
 
 =item get_private_key_string
 
-Return the DER-encoded PKCS1 representation of the private key.
+Return the Base64/DER-encoded PKCS1 representation of the private
+key.  This string has
+header and footer lines:
+
+  -----BEGIN RSA PRIVATE KEY------
+  -----END RSA PRIVATE KEY------
 
 =item encrypt
 


### PR DESCRIPTION
When I read the docs I was surprised to see that there wasn't a mechanism to export the PEM version of the private key. Upon trial however I noticed that get_private_key_string does in fact do that though it is documented to return the DER. This PR corrects that documentation