### PR TITLE
Purge trailing whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,7 +7,7 @@ Revision history for Perl extension Crypt::OpenSSL::RSA.
         - RT 65947 - Fix RSA.pm break with perl 5.14+
 
 0.26  Sun Nov 22 2009 11:01:13
-        - Change subclassing test to generate a 512 bit key in order to work 
+        - Change subclassing test to generate a 512 bit key in order to work
           around an odd issue seen on some 64-bit redhat systems. (CPAN bug 45498)
 
 0.25  Sun May 20 2007 12:56:11

--- a/LICENSE
+++ b/LICENSE
@@ -286,21 +286,21 @@ Definitions:
 
 -    "Package" refers to the collection of files distributed by the Copyright
      Holder, and derivatives of that collection of files created through textual
-     modification. 
+     modification.
 -    "Standard Version" refers to such a Package if it has not been modified,
      or has been modified in accordance with the wishes of the Copyright
-     Holder. 
+     Holder.
 -    "Copyright Holder" is whoever is named in the copyright or copyrights for
-     the package. 
+     the package.
 -    "You" is you, if you're thinking about copying or distributing this Package.
 -    "Reasonable copying fee" is whatever you can justify on the basis of
      media cost, duplication charges, time of people involved, and so on. (You
      will not be required to justify it to the Copyright Holder, but only to the
-     computing community at large as a market that must bear the fee.) 
+     computing community at large as a market that must bear the fee.)
 -    "Freely Available" means that no fee is charged for the item itself, though
      there may be fees involved in handling the item. It also means that
      recipients of the item may redistribute it under the same conditions they
-     received it. 
+     received it.
 
 1. You may make and give away verbatim copies of the source form of the
 Standard Version of this Package without restriction, provided that you duplicate


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged.  If you have any questions or comments concerning the PR, please simply contact me!
