### PR TITLE
Add a LICENSE section to the main module

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -309,6 +309,10 @@ There is a small memory leak when generating new keys of more than 512 bits.
 Ian Robertson, iroberts@cpan.org.  For support, please email
 perl-openssl-users@lists.sourceforge.net.
 
+=head1 LICENSE
+
+This module is released under the same terms as Perl itself.
+
 =head1 SEE ALSO
 
 L<perl(1)>, L<Crypt::OpenSSL::Random(3)>, L<Crypt::OpenSSL::Bignum(3)>,


### PR DESCRIPTION
A LICENSE section in the main module of a distribution is seen as a core
kwalitee issue (see for instance the [corresponding CPANTS
page](http://cpants.cpanauthors.org/dist/Crypt-OpenSSL-RSA)).  The text
added here fixes the `has_license_in_source_file` and
`has_known_license_in_source_file` kwalitee issues (as checked by
`Test::Kwalitee::Extra`.  The license text was chosen based upon the
LICENSE file already provided in the distribution.

This PR is intended to be helpful.  If it needs to be changed in any way, please just let me know and I'll update it and resubmit.
