### PR TITLE
Set the minimum Perl version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.48;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 
@@ -12,6 +12,7 @@ WriteMakefile(
      AUTHOR  => 'Ian Robertson <iroberts@cpan.org>',
     'VERSION_FROM' => 'RSA.pm', # finds $VERSION
     'ABSTRACT_FROM' => 'RSA.pm',
+    'MIN_PERL_VERSION' => 5.006,
     'PL_FILES' => {},
     ($ExtUtils::MakeMaker::VERSION >= 6.3002 ? ('LICENSE'        => 'perl', ) : ()),
     'PREREQ_PM' => {


### PR DESCRIPTION
Setting the minimum Perl version in the dist's metadata is considered good
practice (see for instance
[CPANTS](http://cpants.cpanauthors.org/dist/Crypt-OpenSSL-RSA) and [Neil
Bower's blog post concerning the
issue](http://blogs.perl.org/users/neilb/2014/08/specify-the-min-perl-version-for-your-distribution.html)).
This change thus also fixes the `meta_yml_declares_perl_version` core
kwalitee issue.

This PR is submitted in the hope that it is helpful.  If it needs to be changed in any way, please just let me know and I'll update it and resubmit.
